### PR TITLE
Disable ESLint linebreak-style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "react/prop-types": "off",
         "react/jsx-props-no-spreading": "off",
         "jsx-a11y/anchor-is-valid": "off",
-        "jsx-a11y/label-has-associated-control": "off"
+        "jsx-a11y/label-has-associated-control": "off",
+        "linebreak-style": "off"
     },
     "ignorePatterns": "src/CometChatWorkspace/**/*.js"
 }


### PR DESCRIPTION
Added rule to disable eslint linebreak-style so that the app will run on Windows. The app builds correctly but when it runs on Windows currently a ton of "error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style" are generated when loading the splash screen on Windows. Add the rule ""linebreak-style": "off"" to .eslintrc.json allows the app to run on Windows and Mac using the locally configured linebreak style.